### PR TITLE
Pass block index to unpack callback so custom constraints can be validated

### DIFF
--- a/ert.cpp
+++ b/ert.cpp
@@ -332,7 +332,7 @@ namespace ert
 			const color_rgba* pPixels = &pBlock_pixels[block_index * total_block_pixels];
 
 			color_rgba decoded_block[MAX_BLOCK_PIXELS];
-			if (!(*pUnpack_block_func)(pOrig_block, decoded_block, pUnpack_block_func_user_data))
+			if (!(*pUnpack_block_func)(pOrig_block, decoded_block, block_index, pUnpack_block_func_user_data))
 				return false;
 
 			float cur_mse = compute_block_mse(pPixels, decoded_block, block_width, block_height, total_block_pixels, num_comps, params.m_color_weights, one_over_total_color_weight);
@@ -443,7 +443,7 @@ namespace ert
 								memcpy(trial_block + dst_ofs, pPrev_blk + src_ofs, len);
 
 								color_rgba decoded_trial_block[MAX_BLOCK_PIXELS];
-								if (!(*pUnpack_block_func)(trial_block, decoded_trial_block, pUnpack_block_func_user_data))
+								if (!(*pUnpack_block_func)(trial_block, decoded_trial_block, block_index, pUnpack_block_func_user_data))
 									continue;
 
 								float trial_mse = compute_block_mse(pPixels, decoded_trial_block, block_width, block_height, total_block_pixels, num_comps, params.m_color_weights, one_over_total_color_weight);
@@ -532,7 +532,7 @@ namespace ert
 							memcpy(trial_block + ofs, pPrev_blk + ofs, len);
 
 							color_rgba decoded_trial_block[MAX_BLOCK_PIXELS];
-							if (!(*pUnpack_block_func)(trial_block, decoded_trial_block, pUnpack_block_func_user_data))
+							if (!(*pUnpack_block_func)(trial_block, decoded_trial_block, block_index, pUnpack_block_func_user_data))
 								continue;
 
 							float trial_mse = compute_block_mse(pPixels, decoded_trial_block, block_width, block_height, total_block_pixels, num_comps, params.m_color_weights, one_over_total_color_weight);

--- a/ert.h
+++ b/ert.h
@@ -66,7 +66,7 @@ namespace ert
 		}
 	};
 
-	typedef bool (*pUnpack_block_func)(const void* pBlock, color_rgba* pPixels, void* pUser_data);
+	typedef bool (*pUnpack_block_func)(const void* pBlock, color_rgba* pPixels, uint32_t block_index, void* pUser_data);
 
 	// BC7 entropy reduction transform with Deflate/LZMA/LZHAM optimizations
 	bool reduce_entropy(void* pBlocks, uint32_t num_blocks,

--- a/test.cpp
+++ b/test.cpp
@@ -1007,8 +1007,10 @@ int main(int argc, char *argv[])
 			bool m_allow_3color_mode;
 			bool m_use_bc1_3color_mode_for_black;
 
-			static bool unpack_bc1_block(const void* pBlock, ert::color_rgba* pPixels, void* pUser_data)
+			static bool unpack_bc1_block(const void* pBlock, ert::color_rgba* pPixels, uint32_t block_index, void* pUser_data)
 			{
+				(void)block_index;
+
 				const unpacker_funcs* pState = (const unpacker_funcs*)pUser_data;
 								
 				bool used_3color_mode = rgbcx::unpack_bc1(pBlock, pPixels, true, pState->m_mode);
@@ -1036,16 +1038,18 @@ int main(int argc, char *argv[])
 				return true;
 			}
 
-			static bool unpack_bc4_block(const void* pBlock, ert::color_rgba* pPixels, void* pUser_data)
+			static bool unpack_bc4_block(const void* pBlock, ert::color_rgba* pPixels, uint32_t block_index, void* pUser_data)
 			{
+				(void)block_index;
 				(void)pUser_data;
 				memset(pPixels, 0, sizeof(ert::color_rgba) * 16);
 				rgbcx::unpack_bc4(pBlock, (uint8_t*)pPixels, 4);
 				return true;
 			}
 
-			static bool unpack_bc7_block(const void* pBlock, ert::color_rgba* pPixels, void* pUser_data)
+			static bool unpack_bc7_block(const void* pBlock, ert::color_rgba* pPixels, uint32_t block_index, void* pUser_data)
 			{
+				(void)block_index;
 				(void)pUser_data;
 				return bc7decomp::unpack_bc7(pBlock, (bc7decomp::color_rgba*)pPixels);
 			}


### PR DESCRIPTION
This passes the block index to the unpack callback so that the callback can check if an input-dependent constraint that the encoder was adhering to (like CVTT's strict punchthrough flag) was violated by the ERT candidate, and reject it as invalid if so.

ASTC could also use this to reject any changes to void-extent blocks.