### PR TITLE
BC4/5 fixes and performance improvements

### DIFF
--- a/rgbcx.h
+++ b/rgbcx.h
@@ -388,6 +388,7 @@ namespace rgbcx
 			return (selector_bits >> (((y * 4) + x) * cBC4SelectorBits)) & (cMaxSelectorValues - 1);
 		}
 
+		// Interpolated values as 8-bit (as per BC3 alpha)
 		static inline uint32_t get_block_values6(uint8_t* pDst, uint32_t l, uint32_t h)
 		{
 			pDst[0] = static_cast<uint8_t>(l);
@@ -401,6 +402,23 @@ namespace rgbcx
 			return 6;
 		}
 
+		// Interpolated values expanded to 16-bit (as per BC4/5)
+		static inline uint32_t get_block_values6(uint16_t* pDst, uint32_t l, uint32_t h)
+		{
+			uint32_t l16 = (l << 8) | l;
+			uint32_t h16 = (h << 8) | h;
+			pDst[0] = static_cast<uint8_t>(l16);
+			pDst[1] = static_cast<uint8_t>(h16);
+			pDst[2] = static_cast<uint8_t>((l16 * 4 + h16    ) / 5);
+			pDst[3] = static_cast<uint8_t>((l16 * 3 + h16 * 2) / 5);
+			pDst[4] = static_cast<uint8_t>((l16 * 2 + h16 * 3) / 5);
+			pDst[5] = static_cast<uint8_t>((l16     + h16 * 4) / 5);
+			pDst[6] = 0;
+			pDst[7] = 65535;
+			return 6;
+		}
+
+		// Interpolated values as 8-bit (as per BC3 alpha)
 		static inline uint32_t get_block_values8(uint8_t* pDst, uint32_t l, uint32_t h)
 		{
 			pDst[0] = static_cast<uint8_t>(l);
@@ -414,7 +432,31 @@ namespace rgbcx
 			return 8;
 		}
 
+		// Interpolated values expanded to 16-bit (as per BC4/5)
+		static inline uint32_t get_block_values8(uint16_t* pDst, uint32_t l, uint32_t h)
+		{
+			uint32_t l16 = (l << 8) | l;
+			uint32_t h16 = (h << 8) | h;
+			pDst[0] = static_cast<uint16_t>(l16);
+			pDst[1] = static_cast<uint16_t>(h16);
+			pDst[2] = static_cast<uint16_t>((l16 * 6 + h16    ) / 7);
+			pDst[3] = static_cast<uint16_t>((l16 * 5 + h16 * 2) / 7);
+			pDst[4] = static_cast<uint16_t>((l16 * 4 + h16 * 3) / 7);
+			pDst[5] = static_cast<uint16_t>((l16 * 3 + h16 * 4) / 7);
+			pDst[6] = static_cast<uint16_t>((l16 * 2 + h16 * 5) / 7);
+			pDst[7] = static_cast<uint16_t>((l16     + h16 * 6) / 7);
+			return 8;
+		}
+
 		static inline uint32_t get_block_values(uint8_t* pDst, uint32_t l, uint32_t h)
+		{
+			if (l > h)
+				return get_block_values8(pDst, l, h);
+			else
+				return get_block_values6(pDst, l, h);
+		}
+
+		static inline uint32_t get_block_values(uint16_t* pDst, uint32_t l, uint32_t h)
 		{
 			if (l > h)
 				return get_block_values8(pDst, l, h);


### PR DESCRIPTION
This fixes #17 but goes further:

Two value blocks are special-cased to use the two endpoints by zeroing the search radius, which has a nice side effect of improving performance.

The interpolated values are expanded to 16-bit, then the accumulated error calculated from that. Given an 8-bit PNG source this will bring the error closer to the original (since the BC4/5 hardware uses interpolations with more bits, this keeps trying for the most accurate match).

An early out is taken when the error reaches zero (otherwise the search continues but will never improve upon the best error).

There is no best choice for the expanded endpoints and interpolations. [Ryg's blog entry](https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/) has calculations for Intel, AMD and Nvidia, and they all differ. I went with bit expansion to 16-bit before applying the interpolations.

Fundamentally this _does_ change how all BC3 alpha and BC4/5 encoding works, so ideally it wants the error metric comparing before and after this change. That said, for BC4/5 this should be closer to the originals, and observationally on the nmaps I've been testing with it does appear closer to the original uncompressed version than before. For greyscale maps I looked at the diffs (edges look less harsh) but not yet run metrics.