### PR TITLE
Fixed: Build for GCC

### DIFF
--- a/ert.h
+++ b/ert.h
@@ -9,6 +9,7 @@
 #include <time.h>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace ert
 {


### PR DESCRIPTION
Currently running the following incantation
```
cmake -D SUPPORT_BC7E=FALSE .
make
```

Causes a build error under GCC, due to `cstdint` not being a standard import.
This PR just adds one line to make it buildable out of the box.

-----------

Compiler used:

```
➜  bc7enc-rdo git:(master) ✗ cc --version
cc (GCC) 14.2.1 20240910
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

On (Arch)linux